### PR TITLE
Tcpstreampump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,8 +1,10 @@
 [root]
 name = "git-hive-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11,16 +13,50 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rmp"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.15"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "git-hive-protocol"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mrhwick <matt.hardwick@getbellhops.com>"]
 
-[dependencies.rmp]
+[dependencies]
+time = "0.1.32"
 rmp = "0.5.1"
+byteorder = "0.3.11"

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,11 +1,16 @@
+extern crate byteorder;
+extern crate time;
+
+use self::byteorder::BigEndian;
+use self::byteorder::ByteOrder;
+use self::time::Timespec;
+
 use std::io::{Error, ErrorKind};
 use std::io::Read;
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::thread::JoinHandle;
 use std::string::String;
-
-use message_structures::bytes_to_u16;
 
 pub fn start_listening_for_peers(port: u16) -> JoinHandle<()> {
 	let tcp_listener = TcpListener::bind(("0.0.0.0", port)).unwrap();
@@ -31,6 +36,9 @@ fn read_bytes_from_stream(stream: &TcpStream, number_of_bytes: u32) -> Result<Ve
 
 fn handle_connection(stream: TcpStream) -> Result<(), Error>{
 	println!("Got a connection from a peer!");
+	println!("");
+
+
 
 	// Check protocol name and version
 
@@ -38,8 +46,11 @@ fn handle_connection(stream: TcpStream) -> Result<(), Error>{
 	let procotol_name = try!(read_bytes_from_stream(&stream, protocol_name_length[0] as u32));
 	let protocol_version_length = try!(read_bytes_from_stream(&stream, 1));
 	let protocol_version = try!(read_bytes_from_stream(&stream, protocol_version_length[0] as u32));
-	let message_id = bytes_to_u16(&try!(read_bytes_from_stream(&stream, 2)));
-	let message_type = bytes_to_u16(&try!(read_bytes_from_stream(&stream, 2)));
+
+	// Get message identifier and type.
+
+	let message_id = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
+	let message_type = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
 
 
 	println!("Received message with following information:");
@@ -47,16 +58,106 @@ fn handle_connection(stream: TcpStream) -> Result<(), Error>{
 	println!("Protocol Version: {:?}", String::from_utf8(protocol_version).unwrap());
 	println!("Message ID: {:?}", message_id);
 	println!("Message Type: {:?}", message_type);
+	println!("");
 
 	if message_type == 0 {
 		println!("Swarm Config Options");
+
+		// Get client name & version information.
+
 		let client_name_length = try!(read_bytes_from_stream(&stream, 1));
 		let client_name = try!(read_bytes_from_stream(&stream, client_name_length[0] as u32));
 		let client_version_length = try!(read_bytes_from_stream(&stream, 1));
 		let client_version = try!(read_bytes_from_stream(&stream, client_version_length[0] as u32));
 
+
 		println!("Client Name: {:?}", String::from_utf8(client_name).unwrap());
 		println!("Client Version: {:?}", String::from_utf8(client_version).unwrap());
+
+		// Get repository information.
+
+		println!("Interested in the following repos:");
+		let number_of_repositories = try!(read_bytes_from_stream(&stream, 1));
+		for i in 0..number_of_repositories[0] {
+			let repository_path_length = try!(read_bytes_from_stream(&stream, 1));
+			let repository_path = try!(read_bytes_from_stream(&stream, repository_path_length[0] as u32));
+			println!("{:?}", String::from_utf8(repository_path).unwrap());			
+		}
+	}
+	println!("");
+	println!("");
+	println!("");
+
+	// Check protocol name and version
+
+	let protocol_name_length = try!(read_bytes_from_stream(&stream, 1));
+	let procotol_name = try!(read_bytes_from_stream(&stream, protocol_name_length[0] as u32));
+	let protocol_version_length = try!(read_bytes_from_stream(&stream, 1));
+	let protocol_version = try!(read_bytes_from_stream(&stream, protocol_version_length[0] as u32));
+
+	// Get message identifier and type.
+
+	let message_id = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
+	let message_type = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
+
+
+	println!("Received message with following information:");
+	println!("Protocol Name: {:?}", String::from_utf8(procotol_name).unwrap());
+	println!("Protocol Version: {:?}", String::from_utf8(protocol_version).unwrap());
+	println!("Message ID: {:?}", message_id);
+	println!("Message Type: {:?}", message_type);
+	println!("");
+
+	if message_type == 1 {
+		println!("Repository Index Information");
+
+		// Get client name & version information.
+
+		let number_of_directories = try!(read_bytes_from_stream(&stream, 1));
+		for i in 0..number_of_directories[0] {
+			let directory_path_length = try!(read_bytes_from_stream(&stream, 1));
+			let directory_path = try!(read_bytes_from_stream(&stream, directory_path_length[0] as u32));
+
+			println!("Directory: {:?}", String::from_utf8(directory_path).unwrap());
+
+			let number_of_files = try!(read_bytes_from_stream(&stream, 1));
+			for j in 0..number_of_files[0] {
+				let length_filename = try!(read_bytes_from_stream(&stream, 1));
+				let filename = try!(read_bytes_from_stream(&stream, length_filename[0] as u32));
+
+				println!("Filename: {:?}", String::from_utf8(filename).unwrap());
+
+				let timespec_seconds = BigEndian::read_i64(&try!(read_bytes_from_stream(&stream, 8)));
+				let timespec_nanoseconds = BigEndian::read_i32(&try!(read_bytes_from_stream(&stream, 4)));
+				let time_in_tm = time::at(Timespec::new(timespec_seconds, timespec_nanoseconds));
+
+				println!("Modified Time: {:?}", time::strftime("%F %T", &time_in_tm).unwrap());
+
+				let version_counter = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
+				let local_version = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
+
+				println!("Version Counter: {:?}", version_counter);
+				println!("Local Version: {:?}", local_version);
+
+				let number_of_blocks = try!(read_bytes_from_stream(&stream, 1));
+
+				println!("Block Count: {:?} blocks", number_of_blocks[0]);
+
+				for k in 0..number_of_blocks[0] {
+
+					println!("Block {:?}: ", i);
+
+					let size = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
+
+					println!("Size: {:?}", size);
+
+					let hash_length = try!(read_bytes_from_stream(&stream, 1));
+					let hash = try!(read_bytes_from_stream(&stream, hash_length[0] as u32));
+
+					println!("Hash: {:?}", String::from_utf8(hash).unwrap());
+				}
+			}
+		}
 	}
 
 	Ok(())

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,8 +1,5 @@
-extern crate byteorder;
 extern crate time;
 
-use self::byteorder::BigEndian;
-use self::byteorder::ByteOrder;
 use self::time::Timespec;
 
 use std::io::{Error, ErrorKind};
@@ -12,156 +9,17 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::string::String;
 
+use streamutils::read_bytes_from_stream;
+use streamutils::TcpStreamPump;
+
 pub fn start_listening_for_peers(port: u16) -> JoinHandle<()> {
 	let tcp_listener = TcpListener::bind(("0.0.0.0", port)).unwrap();
 	thread::spawn(move || {
 		for stream in tcp_listener.incoming() {
 			match stream {
-				Ok(s) => handle_connection(s),
+				Ok(s) => {TcpStreamPump::start_pumping_message_to_channel(s); Ok(())},
 				Err(e) => Err(e),
 			};
 		}
 	})
-}
-
-fn read_bytes_from_stream(stream: &TcpStream, number_of_bytes: u32) -> Result<Vec<u8>, Error> {
-	let mut buffer = vec![];
-	let bytes_read = stream.take(number_of_bytes as u64).read_to_end(&mut buffer);
-	match bytes_read {
-		Ok(n) if n == number_of_bytes as usize => Ok(buffer),
-		Ok(n) => Err(Error::new(ErrorKind::Other, format!("Not Enough Data! {}", n))),
-        Err(e) => Err(e),
-	}
-}
-
-fn handle_connection(stream: TcpStream) -> Result<(), Error>{
-	println!("Got a connection from a peer!");
-	println!("");
-
-
-
-	// Check protocol name and version
-
-	let protocol_name_length = try!(read_bytes_from_stream(&stream, 1));
-	let procotol_name = try!(read_bytes_from_stream(&stream, protocol_name_length[0] as u32));
-	let protocol_version_length = try!(read_bytes_from_stream(&stream, 1));
-	let protocol_version = try!(read_bytes_from_stream(&stream, protocol_version_length[0] as u32));
-
-	// Get message identifier and type.
-
-	let message_id = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
-	let message_type = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
-
-
-	println!("Received message with following information:");
-	println!("Protocol Name: {:?}", String::from_utf8(procotol_name).unwrap());
-	println!("Protocol Version: {:?}", String::from_utf8(protocol_version).unwrap());
-	println!("Message ID: {:?}", message_id);
-	println!("Message Type: {:?}", message_type);
-	println!("");
-
-	if message_type == 0 {
-		println!("Swarm Config Options");
-
-		// Get client name & version information.
-
-		let client_name_length = try!(read_bytes_from_stream(&stream, 1));
-		let client_name = try!(read_bytes_from_stream(&stream, client_name_length[0] as u32));
-		let client_version_length = try!(read_bytes_from_stream(&stream, 1));
-		let client_version = try!(read_bytes_from_stream(&stream, client_version_length[0] as u32));
-
-
-		println!("Client Name: {:?}", String::from_utf8(client_name).unwrap());
-		println!("Client Version: {:?}", String::from_utf8(client_version).unwrap());
-
-		// Get repository information.
-
-		println!("Interested in the following repos:");
-		let number_of_repositories = try!(read_bytes_from_stream(&stream, 1));
-		for i in 0..number_of_repositories[0] {
-			let repository_path_length = try!(read_bytes_from_stream(&stream, 1));
-			let repository_path = try!(read_bytes_from_stream(&stream, repository_path_length[0] as u32));
-			println!("{:?}", String::from_utf8(repository_path).unwrap());			
-		}
-	}
-	println!("");
-	println!("");
-	println!("");
-
-	// Check protocol name and version
-
-	let protocol_name_length = try!(read_bytes_from_stream(&stream, 1));
-	let procotol_name = try!(read_bytes_from_stream(&stream, protocol_name_length[0] as u32));
-	let protocol_version_length = try!(read_bytes_from_stream(&stream, 1));
-	let protocol_version = try!(read_bytes_from_stream(&stream, protocol_version_length[0] as u32));
-
-	// Get message identifier and type.
-
-	let message_id = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
-	let message_type = BigEndian::read_u16(&try!(read_bytes_from_stream(&stream, 2)));
-
-
-	println!("Received message with following information:");
-	println!("Protocol Name: {:?}", String::from_utf8(procotol_name).unwrap());
-	println!("Protocol Version: {:?}", String::from_utf8(protocol_version).unwrap());
-	println!("Message ID: {:?}", message_id);
-	println!("Message Type: {:?}", message_type);
-	println!("");
-
-	if message_type == 1 {
-		println!("Repository Index Information");
-
-		// Get client name & version information.
-
-		let number_of_directories = try!(read_bytes_from_stream(&stream, 1));
-		for i in 0..number_of_directories[0] {
-			let directory_path_length = try!(read_bytes_from_stream(&stream, 1));
-			let directory_path = try!(read_bytes_from_stream(&stream, directory_path_length[0] as u32));
-
-			println!("Directory: {:?}", String::from_utf8(directory_path).unwrap());
-
-			let number_of_files = try!(read_bytes_from_stream(&stream, 1));
-			for j in 0..number_of_files[0] {
-				let length_filename = try!(read_bytes_from_stream(&stream, 1));
-				let filename = try!(read_bytes_from_stream(&stream, length_filename[0] as u32));
-
-				println!("Filename: {:?}", String::from_utf8(filename).unwrap());
-
-				let timespec_seconds = BigEndian::read_i64(&try!(read_bytes_from_stream(&stream, 8)));
-				let timespec_nanoseconds = BigEndian::read_i32(&try!(read_bytes_from_stream(&stream, 4)));
-				let time_in_tm = time::at(Timespec::new(timespec_seconds, timespec_nanoseconds));
-
-				println!("Modified Time: {:?}", time::strftime("%F %T", &time_in_tm).unwrap());
-
-				let version_counter = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
-				let local_version = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
-
-				println!("Version Counter: {:?}", version_counter);
-				println!("Local Version: {:?}", local_version);
-
-				let number_of_blocks = try!(read_bytes_from_stream(&stream, 1));
-
-				println!("Block Count: {:?} blocks", number_of_blocks[0]);
-
-				for k in 0..number_of_blocks[0] {
-
-					println!("Block {:?}: ", i);
-
-					let size = BigEndian::read_u32(&try!(read_bytes_from_stream(&stream, 4)));
-
-					println!("Size: {:?}", size);
-
-					let hash_length = try!(read_bytes_from_stream(&stream, 1));
-					let hash = try!(read_bytes_from_stream(&stream, hash_length[0] as u32));
-
-					println!("Hash: {:?}", String::from_utf8(hash).unwrap());
-				}
-			}
-		}
-	}
-
-	Ok(())
-
-	// Initiate connection for peering as usual.
-		
 }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,15 +1,7 @@
-extern crate time;
-
-use self::time::Timespec;
-
-use std::io::{Error, ErrorKind};
-use std::io::Read;
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
 use std::thread;
 use std::thread::JoinHandle;
-use std::string::String;
 
-use streamutils::read_bytes_from_stream;
 use streamutils::TcpStreamPump;
 
 pub fn start_listening_for_peers(port: u16) -> JoinHandle<()> {
@@ -19,7 +11,7 @@ pub fn start_listening_for_peers(port: u16) -> JoinHandle<()> {
 			match stream {
 				Ok(s) => {TcpStreamPump::start_pumping_message_to_channel(s); Ok(())},
 				Err(e) => Err(e),
-			};
+			}.unwrap();
 		}
 	})
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,16 @@ extern crate byteorder;
 
 use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
 
-mod listener;
-mod message_structures;
-mod streamutils;
-
 use std::io::prelude::*;
 use std::net::TcpStream;
 use std::string::String;
+
+mod listener;
+mod message_structures;
+mod streamutils;
+mod shared_constants;
+
+use shared_constants::{CLIENT_NAME, CLIENT_VERSION, PROTOCOL_NAME, PROTOCOL_VERSION};
 
 fn main() {
 
@@ -24,22 +27,13 @@ fn main() {
     // The following code initiates a connection and sends hello world.
 
     let mut stream = TcpStream::connect(("0.0.0.0", 33317)).unwrap();
-    
-    let protocol_name = String::from("Git Hive Protocol");
-    let protocol_version = String::from("0.0.1");
-    let client_name = String::from("Git Hive");
-    let client_version = String::from("0.0.1");
 
     let repo_path = String::from("/githive/githive-protocol");
     let repo_path_two = String::from("/githive/githive-client");
 
-        // protocol_name: protocol_name.into_bytes(),
-        // protocol_version: protocol_version.into_bytes(),
-        // message_id: 51733 as u16,
-        // message_type: 0 as u16,
     let message = message_structures::Message::SwarmConfigurationMessage{
-        client_name: client_name.into_bytes(),
-        client_version: client_version.into_bytes(),
+        client_name: String::from(CLIENT_NAME).into_bytes(),
+        client_version: String::from(CLIENT_VERSION).into_bytes(),
         repositories: vec![
             message_structures::RepositoryInformation{
                 path: repo_path.into_bytes(),
@@ -51,10 +45,10 @@ fn main() {
     };
 
     let mut message_metadata = vec![];
-    message_metadata.push(protocol_name.len() as u8);
-    message_metadata.extend(protocol_name.into_bytes());
-    message_metadata.push(protocol_version.len() as u8);
-    message_metadata.extend(protocol_version.into_bytes());
+    message_metadata.push(PROTOCOL_NAME.len() as u8);
+    message_metadata.extend(String::from(PROTOCOL_NAME).into_bytes());
+    message_metadata.push(PROTOCOL_VERSION.len() as u8);
+    message_metadata.extend(String::from(PROTOCOL_VERSION).into_bytes());
 
     let mut message_id_buf = vec![];
     message_id_buf.write_u16::<BigEndian>(51733 as u16).unwrap();
@@ -66,7 +60,7 @@ fn main() {
 
     message_metadata.extend(message.serialize().unwrap());
 
-    stream.write_all(&message_metadata);
+    stream.write_all(&message_metadata).unwrap();
 
     let protocol_name = String::from("Git Hive Protocol");
     let protocol_version = String::from("0.0.1");
@@ -115,7 +109,7 @@ fn main() {
 
     message_metadata.extend(message.serialize().unwrap());
 
-    stream.write_all(&message_metadata);
+    stream.write_all(&message_metadata).unwrap();
 
     // let _ = stream.write_all(&message.serialize());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 extern crate rmp as msgpack;
 extern crate time as time;
+extern crate byteorder;
+
+use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
 
 mod listener;
 mod message_structures;
+mod streamutils;
 
 use std::io::prelude::*;
 use std::net::TcpStream;
 use std::string::String;
-
-use message_structures::Messageable;
 
 fn main() {
 
@@ -31,31 +33,43 @@ fn main() {
     let repo_path = String::from("/githive/githive-protocol");
     let repo_path_two = String::from("/githive/githive-client");
 
-    let message = message_structures::Message{
-        protocol_name: protocol_name.into_bytes(),
-        protocol_version: protocol_version.into_bytes(),
-        message_id: 51733 as u16,
-        message_type: 0 as u16,
-        real_message: &message_structures::SwarmConfigurationMessage{
-            client_name: client_name.into_bytes(),
-            client_version: client_version.into_bytes(),
-            repositories: vec![
-                message_structures::RepositoryInformation{
-                    path: repo_path.into_bytes(),
-                },
-                message_structures::RepositoryInformation{
-                    path: repo_path_two.into_bytes(),
-                }
-            ],
-        },
+        // protocol_name: protocol_name.into_bytes(),
+        // protocol_version: protocol_version.into_bytes(),
+        // message_id: 51733 as u16,
+        // message_type: 0 as u16,
+    let message = message_structures::Message::SwarmConfigurationMessage{
+        client_name: client_name.into_bytes(),
+        client_version: client_version.into_bytes(),
+        repositories: vec![
+            message_structures::RepositoryInformation{
+                path: repo_path.into_bytes(),
+            },
+            message_structures::RepositoryInformation{
+                path: repo_path_two.into_bytes(),
+            }
+        ],
     };
 
-    let _ = stream.write_all(&message.serialize());
+    let mut message_metadata = vec![];
+    message_metadata.push(protocol_name.len() as u8);
+    message_metadata.extend(protocol_name.into_bytes());
+    message_metadata.push(protocol_version.len() as u8);
+    message_metadata.extend(protocol_version.into_bytes());
+
+    let mut message_id_buf = vec![];
+    message_id_buf.write_u16::<BigEndian>(51733 as u16).unwrap();
+    message_metadata.extend(message_id_buf.into_iter());
+
+    let mut message_type_buf = vec![];
+    message_type_buf.write_u16::<BigEndian>(0 as u16).unwrap();
+    message_metadata.extend(message_type_buf.into_iter());
+
+    message_metadata.extend(message.serialize().unwrap());
+
+    stream.write_all(&message_metadata);
 
     let protocol_name = String::from("Git Hive Protocol");
     let protocol_version = String::from("0.0.1");
-    let client_name = String::from("Git Hive");
-    let client_version = String::from("0.0.1");
 
     let directory_one = String::from("/");
 
@@ -63,35 +77,47 @@ fn main() {
 
     let block_hash = String::from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
-    let message = message_structures::Message {
-        protocol_name: protocol_name.into_bytes(),
-        protocol_version: protocol_version.into_bytes(),
-        message_id: 51734 as u16,
-        message_type: 1 as u16,
-        real_message: &message_structures::RepositoryIndexMessage{
-            directories: vec![
-                message_structures::DirectoryInformation{
-                    directory_path: directory_one.into_bytes(),
-                    files: vec![
-                        message_structures::FileInformation{
-                            filename: file_one_name.into_bytes(),
-                            modified: time::get_time(),
-                            version: 0 as u32,
-                            local_version: 0 as u32,
-                            blocks: vec![
-                                message_structures::BlockInformation{
-                                    size: 1 as u32,
-                                    hash: block_hash.into_bytes(),
-                                }
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
+    let message = message_structures::Message::RepositoryIndexMessage {
+        directories: vec![
+            message_structures::DirectoryInformation{
+                directory_path: directory_one.into_bytes(),
+                files: vec![
+                    message_structures::FileInformation{
+                        filename: file_one_name.into_bytes(),
+                        modified: time::get_time(),
+                        version: 0 as u32,
+                        local_version: 0 as u32,
+                        blocks: vec![
+                            message_structures::BlockInformation{
+                                size: 1 as u32,
+                                hash: block_hash.into_bytes(),
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
     };
 
-    let _ = stream.write_all(&message.serialize());
+    let mut message_metadata = vec![];
+    message_metadata.push(protocol_name.len() as u8);
+    message_metadata.extend(protocol_name.into_bytes());
+    message_metadata.push(protocol_version.len() as u8);
+    message_metadata.extend(protocol_version.into_bytes());
+
+    let mut message_id_buf = vec![];
+    message_id_buf.write_u16::<BigEndian>(51734 as u16).unwrap();
+    message_metadata.extend(message_id_buf.into_iter());
+
+    let mut message_type_buf = vec![];
+    message_type_buf.write_u16::<BigEndian>(1 as u16).unwrap();
+    message_metadata.extend(message_type_buf.into_iter());
+
+    message_metadata.extend(message.serialize().unwrap());
+
+    stream.write_all(&message_metadata);
+
+    // let _ = stream.write_all(&message.serialize());
 
     loop {
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate rmp as msgpack;
+extern crate time as time;
 
 mod listener;
 mod message_structures;
@@ -27,18 +28,66 @@ fn main() {
     let client_name = String::from("Git Hive");
     let client_version = String::from("0.0.1");
 
+    let repo_path = String::from("/githive/githive-protocol");
+    let repo_path_two = String::from("/githive/githive-client");
+
     let message = message_structures::Message{
-        protocol_name_length: protocol_name.len() as u8,
         protocol_name: protocol_name.into_bytes(),
-        protocol_version_length: protocol_version.len() as u8,
         protocol_version: protocol_version.into_bytes(),
         message_id: 51733 as u16,
         message_type: 0 as u16,
-        real_message: &message_structures::SwarmConfig{
-            client_name_length: client_name.len() as u8,
+        real_message: &message_structures::SwarmConfigurationMessage{
             client_name: client_name.into_bytes(),
-            client_version_length: client_version.len() as u8,
             client_version: client_version.into_bytes(),
+            repositories: vec![
+                message_structures::RepositoryInformation{
+                    path: repo_path.into_bytes(),
+                },
+                message_structures::RepositoryInformation{
+                    path: repo_path_two.into_bytes(),
+                }
+            ],
+        },
+    };
+
+    let _ = stream.write_all(&message.serialize());
+
+    let protocol_name = String::from("Git Hive Protocol");
+    let protocol_version = String::from("0.0.1");
+    let client_name = String::from("Git Hive");
+    let client_version = String::from("0.0.1");
+
+    let directory_one = String::from("/");
+
+    let file_one_name = String::from("README.md");
+
+    let block_hash = String::from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+    let message = message_structures::Message {
+        protocol_name: protocol_name.into_bytes(),
+        protocol_version: protocol_version.into_bytes(),
+        message_id: 51734 as u16,
+        message_type: 1 as u16,
+        real_message: &message_structures::RepositoryIndexMessage{
+            directories: vec![
+                message_structures::DirectoryInformation{
+                    directory_path: directory_one.into_bytes(),
+                    files: vec![
+                        message_structures::FileInformation{
+                            filename: file_one_name.into_bytes(),
+                            modified: time::get_time(),
+                            version: 0 as u32,
+                            local_version: 0 as u32,
+                            blocks: vec![
+                                message_structures::BlockInformation{
+                                    size: 1 as u32,
+                                    hash: block_hash.into_bytes(),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
         },
     };
 

--- a/src/message_structures.rs
+++ b/src/message_structures.rs
@@ -65,7 +65,7 @@ impl Message {
 
 				let number_of_directories = try!(read_bytes_from_stream(&stream, 1));
 
-				for i in 0..number_of_directories[0] {
+				for _ in 0..number_of_directories[0] {
 					let directory_path_length = try!(read_bytes_from_stream(&stream, 1));
 					let directory_path = try!(read_bytes_from_stream(&stream, directory_path_length[0] as u32));
 
@@ -131,7 +131,7 @@ impl Message {
 
 	pub fn serialize(self) -> Result<Vec<u8>, Error> {
 		match self {
-			Message::SwarmConfigurationMessage{client_name: client_name, client_version: client_version, repositories: repositories} => {
+			Message::SwarmConfigurationMessage{client_name, client_version, repositories} => {
 
 				let mut message_payload = vec![];
 				// Client & Version Information
@@ -148,7 +148,7 @@ impl Message {
 
 				Ok(message_payload)
 			},
-			Message::RepositoryIndexMessage{directories: directories} => {
+			Message::RepositoryIndexMessage{directories} => {
 				let mut message_payload = vec![];
 				// Directory Listings
 				message_payload.push(directories.len() as u8);
@@ -162,7 +162,7 @@ impl Message {
 
 	pub fn print_details(self){
 		match self {
-			Message::SwarmConfigurationMessage{client_name: client_name, client_version: client_version, repositories: repositories} => {
+			Message::SwarmConfigurationMessage{client_name, client_version, repositories} => {
 				println!("client name: {:?}", String::from_utf8(client_name).unwrap());
 				println!("client version: {:?}", String::from_utf8(client_version).unwrap());
 				
@@ -172,7 +172,7 @@ impl Message {
 					repo.print_details();
 				}
 			},
-			Message::RepositoryIndexMessage{directories: directories} => {
+			Message::RepositoryIndexMessage{directories} => {
 				for directory in directories {
 					directory.print_details();
 				}

--- a/src/message_structures.rs
+++ b/src/message_structures.rs
@@ -1,69 +1,206 @@
+extern crate byteorder;
+extern crate time;
 
 use std::ops::{Shl, Shr};
+
+use self::byteorder::{BigEndian, WriteBytesExt};
+use self::time::Timespec;
 
 pub trait Messageable {
 	fn serialize(&self) -> Vec<u8>;
 }
 
 pub struct Message<'a> {
-	pub protocol_name_length: u8,
 	pub protocol_name: Vec<u8>,
-	pub protocol_version_length: u8,
     pub protocol_version: Vec<u8>,
     pub message_id: u16,
     pub message_type: u16,
     pub real_message: &'a (Messageable + 'a),
 }
 
-pub fn bytes_to_u16(bytes: &[u8]) -> u16 {
-    (bytes[0] as u16).shl(8) + 
-    bytes[1] as u16
-}
-
-fn u16_to_bytes(integer: u16) -> Vec<u8> {
-    let first = integer.shr(8) as u16;
-    let second = integer - first.shl(8);
-    vec![first as u8, second as u8]
-}
-
 impl<'p> Messageable for Message<'p> {
 	fn serialize(&self) -> Vec<u8> {
 		let mut message_payload = vec![];
-		message_payload.push(self.protocol_name_length);
+
+		// Protocol Name
+
+		message_payload.push(self.protocol_name.len() as u8);
 		message_payload.extend(self.protocol_name.iter().cloned());
-		message_payload.push(self.protocol_version_length);
+		
+		// Protocol Version
+
+		message_payload.push(self.protocol_version.len() as u8);
 		message_payload.extend(self.protocol_version.iter().cloned());
-		message_payload.extend(u16_to_bytes(self.message_id).into_iter());
-		message_payload.extend(u16_to_bytes(self.message_type).into_iter());
+
+		// Message Identifier
+
+		let mut message_id_buf = vec![];
+		message_id_buf.write_u16::<BigEndian>(self.message_id).unwrap();
+		message_payload.extend(message_id_buf.into_iter());
+		
+		// Message Type
+
+		let mut message_type_buf = vec![];
+		message_type_buf.write_u16::<BigEndian>(self.message_type).unwrap();
+		message_payload.extend(message_type_buf.into_iter());
+
+		// Actual Message Serialization
+
 		message_payload.extend(self.real_message.serialize());
 		return message_payload;
 	}
 }
 
-pub struct SwarmConfig {
-	pub client_name_length: u8,
+pub struct SwarmConfigurationMessage {
 	pub client_name: Vec<u8>,
-	pub client_version_length: u8,
 	pub client_version: Vec<u8>,
+	pub repositories: Vec<RepositoryInformation>,
 }
 
-impl Messageable for SwarmConfig {
+impl Messageable for SwarmConfigurationMessage {
 	fn serialize(&self) -> Vec<u8> {
 		let mut message_payload = vec![];
-		message_payload.push(self.client_name_length);
+		// Client & Version Information
+		message_payload.push(self.client_name.len() as u8);
 		message_payload.extend(self.client_name.iter().cloned());
-		message_payload.push(self.client_version_length);
+		message_payload.push(self.client_version.len() as u8);
 		message_payload.extend(self.client_version.iter().cloned());
+
+		// Repo Information.
+		message_payload.push(self.repositories.len() as u8);
+		for repo in &self.repositories {
+			message_payload.extend(repo.serialize());
+		}
+
 		return message_payload;
 	}
 }
 
-// struct Index {
-//     protocol_version: u16,
-//     message_id: u64,
-//     message_type: u16,
-//     length: u64,
-// }
+pub struct RepositoryInformation {
+	pub path: Vec<u8>,
+}
+
+impl Messageable for RepositoryInformation {
+	fn serialize(&self) -> Vec<u8> {
+		let mut message_payload = vec![];
+		message_payload.push(self.path.len() as u8);
+		message_payload.extend(self.path.iter().cloned());
+		return message_payload;
+	}
+}
+
+pub struct RepositoryIndexMessage {
+	pub directories: Vec<DirectoryInformation>,
+}
+
+impl Messageable for RepositoryIndexMessage {
+	fn serialize(&self) -> Vec<u8> {
+		let mut message_payload = vec![];
+		// Directory Listings
+		message_payload.push(self.directories.len() as u8);
+		for directory in &self.directories {
+			message_payload.extend(directory.serialize());
+		}
+		return message_payload;
+	}
+}
+
+pub struct DirectoryInformation {
+	pub directory_path: Vec<u8>,
+	pub files: Vec<FileInformation>,
+}
+
+impl Messageable for DirectoryInformation {
+	fn serialize(&self) -> Vec<u8> {
+		let mut message_payload = vec![];
+		message_payload.push(self.directory_path.len() as u8);
+		message_payload.extend(self.directory_path.iter().cloned());
+
+		message_payload.push(self.files.len() as u8);
+		for file in &self.files {
+			message_payload.extend(file.serialize());
+		}
+		return message_payload;
+	}
+}
+
+pub struct FileInformation {
+	pub filename: Vec<u8>,
+	pub modified: Timespec,
+	pub version: u32,
+	pub local_version: u32,
+	pub blocks: Vec<BlockInformation>,
+}
+
+impl Messageable for FileInformation {
+	fn serialize(&self) -> Vec<u8> {
+		let mut message_payload = vec![];
+
+		// File Name
+
+		message_payload.push(self.filename.len() as u8);
+		message_payload.extend(self.filename.iter().cloned());
+
+		// Modified Timestamp as Time Since Epoch.
+
+		// Seconds Since Epoch
+
+		let mut timespec_second_buf = vec![];
+		timespec_second_buf.write_i64::<BigEndian>(self.modified.sec).unwrap();
+		message_payload.extend(timespec_second_buf.into_iter());
+
+		// Nanoseconds Since Epoch
+
+		let mut timespec_nanosecond_buf = vec![];
+		timespec_nanosecond_buf.write_i32::<BigEndian>(self.modified.nsec).unwrap();
+		message_payload.extend(timespec_nanosecond_buf.into_iter());
+
+		// Version Counter
+
+		let mut version_bytes_buf = vec![];
+		version_bytes_buf.write_u32::<BigEndian>(self.version).unwrap();
+		message_payload.extend(version_bytes_buf.into_iter());
+
+		// Local Version Counter
+
+		let mut local_version_bytes_buf = vec![];
+		local_version_bytes_buf.write_u32::<BigEndian>(self.local_version).unwrap();
+		message_payload.extend(local_version_bytes_buf.into_iter());
+
+		// Block Information Serialization
+
+		message_payload.push(self.blocks.len() as u8);
+		for block in &self.blocks {
+			message_payload.extend(block.serialize());
+		}
+
+		return message_payload;
+	}
+}
+
+pub struct BlockInformation {
+	pub size: u32,
+	pub hash: Vec<u8>,
+}
+
+impl Messageable for BlockInformation {
+	fn serialize(&self) -> Vec<u8> {
+		let mut message_payload = vec![];
+
+		// Block Size
+
+		let mut block_size_bytes_buf = vec![];
+		block_size_bytes_buf.write_u32::<BigEndian>(self.size).unwrap();
+		message_payload.extend(block_size_bytes_buf.into_iter());
+
+		// Block Hash
+
+		message_payload.push(self.hash.len() as u8);
+		message_payload.extend(self.hash.iter().cloned());
+
+		return message_payload;
+	}
+}
 
 // struct Request {
 //     protocol_version: u16,

--- a/src/shared_constants.rs
+++ b/src/shared_constants.rs
@@ -1,0 +1,5 @@
+
+pub const PROTOCOL_NAME : &'static str = "Git Hive Protocol";
+pub const PROTOCOL_VERSION : &'static str = "0.0.1";
+pub const CLIENT_NAME : &'static str = "Git Hive";
+pub const CLIENT_VERSION : &'static str = "0.0.1";

--- a/src/streamutils.rs
+++ b/src/streamutils.rs
@@ -1,0 +1,76 @@
+extern crate byteorder;
+
+use self::byteorder::BigEndian;
+use self::byteorder::ByteOrder;
+
+use std::io::{Error, ErrorKind};
+use std::io::Read;
+use std::net::TcpStream;
+
+use message_structures::Message;
+
+pub fn read_bytes_from_stream(stream: &TcpStream, number_of_bytes: u32) -> Result<Vec<u8>, Error> {
+	let mut buffer = vec![];
+	let bytes_read = stream.take(number_of_bytes as u64).read_to_end(&mut buffer);
+	match bytes_read {
+		Ok(n) if n == number_of_bytes as usize => Ok(buffer),
+		Ok(n) => Err(Error::new(ErrorKind::Other, format!("Not Enough Data! {}", n))),
+        Err(e) => Err(e),
+	}
+}
+
+pub struct TcpStreamPump {
+    stream: TcpStream,
+    // tx: Sender<>,
+}
+
+impl TcpStreamPump {
+    // fn start_pumping_message_to_channel(stream: TcpStream, tx: Sender<>) {
+    pub fn start_pumping_message_to_channel(stream: TcpStream) {
+        let mut funnel = TcpStreamPump {
+            stream: stream,
+        };
+        match funnel.run() {
+            Ok(_) => {},
+            Err(e) => println!("Error: {:?}", e)
+        }
+    }
+
+    fn run(&mut self) -> Result<(), Error> {
+        loop {
+            try!(self.receive_message());
+            // try!(self.tx.send(IPC::Message(message)));
+        }
+    }
+
+    fn receive_message(&mut self) -> Result<(), Error> {
+    	println!("Trying to get a message.");
+
+		// Check protocol name and version
+
+		let protocol_name_length = try!(read_bytes_from_stream(&self.stream, 1));
+		let protocol_name = try!(read_bytes_from_stream(&self.stream, protocol_name_length[0] as u32));
+		let protocol_version_length = try!(read_bytes_from_stream(&self.stream, 1));
+		let protocol_version = try!(read_bytes_from_stream(&self.stream, protocol_version_length[0] as u32));
+
+		println!("Got some meta data!\n");
+
+		println!("protocol name: {:?}", String::from_utf8(protocol_name));
+		println!("protocol version: {:?}", String::from_utf8(protocol_version));
+
+		// Get message identifier and type.
+
+		let message_id = BigEndian::read_u16(&try!(read_bytes_from_stream(&self.stream, 2)));
+		let message_type = BigEndian::read_u16(&try!(read_bytes_from_stream(&self.stream, 2)));
+
+		println!("message ID: {:?}", message_id);
+		println!("Message Type: {:?}", message_type);
+
+		let message = try!(Message::from_stream(message_type, &self.stream));
+
+		message.print_details();
+
+    	println!("\n\n");
+    	Ok(())
+    }
+}

--- a/src/streamutils.rs
+++ b/src/streamutils.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 use std::net::TcpStream;
 
 use message_structures::Message;
+use shared_constants::{PROTOCOL_NAME, PROTOCOL_VERSION};
 
 pub fn read_bytes_from_stream(stream: &TcpStream, number_of_bytes: u32) -> Result<Vec<u8>, Error> {
 	let mut buffer = vec![];
@@ -49,14 +50,18 @@ impl TcpStreamPump {
 		// Check protocol name and version
 
 		let protocol_name_length = try!(read_bytes_from_stream(&self.stream, 1));
-		let protocol_name = try!(read_bytes_from_stream(&self.stream, protocol_name_length[0] as u32));
+		let protocol_name = String::from_utf8(try!(read_bytes_from_stream(&self.stream, protocol_name_length[0] as u32))).unwrap();
 		let protocol_version_length = try!(read_bytes_from_stream(&self.stream, 1));
-		let protocol_version = try!(read_bytes_from_stream(&self.stream, protocol_version_length[0] as u32));
+		let protocol_version = String::from_utf8(try!(read_bytes_from_stream(&self.stream, protocol_version_length[0] as u32))).unwrap();
+
+		if protocol_name != PROTOCOL_NAME || protocol_version != PROTOCOL_VERSION {
+			panic!("Peer sent message with invalid protocol name or version. Expected protocol: '{}', '{}'", PROTOCOL_NAME, PROTOCOL_VERSION);
+		}
 
 		println!("Got some meta data!\n");
 
-		println!("protocol name: {:?}", String::from_utf8(protocol_name));
-		println!("protocol version: {:?}", String::from_utf8(protocol_version));
+		println!("protocol name: {:?}", protocol_name);
+		println!("protocol version: {:?}", protocol_version);
 
 		// Get message identifier and type.
 


### PR DESCRIPTION
## Purpose

We must have some notion of concurrency in this system. In order to achieve highly concurrent network message handling around peer connections, we must have some mechanism to pump message data into the system out of TCP streams.

I wrote a stream pump mechanism that will detect metadata for each message and package up the real message content into a data structure. The TcpStreamPump will now just print out details of any message as the message is received.
## Future Work

In the next iteration of the TcpStreamPump, I would like to have some notion of a MPSC (multiple producer, single consumer) channel. This MPSC channel will be used to pump messages into some controller mechanism over the repository torrent to which the peer is related.
