### PR TITLE
Use separate Structs for interesting repo storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 target
 **.DS_STORE
-cargo.lock
+Cargo.lock

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod streamutils;
 mod shared_constants;
 mod peer_connection;
 mod file_manager;
+mod repositories;
 
 fn main() {
 

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -1,0 +1,38 @@
+
+use errors::Error;
+
+pub struct OwnerTree {
+	pub owner: String,
+	pub repositories: Vec<RepositoryTree>,
+}
+
+impl OwnerTree {
+	pub fn add_repo(&mut self, repository_name: String) -> Result<(), Error> {
+
+		let repo = RepositoryTree {
+			repository_name: repository_name,
+		};
+
+		self.repositories.push(repo);
+		Ok(())
+	}
+
+	pub fn get_repo_names(self) -> Vec<String> {
+		let mut repo_names = vec![];
+
+		for repo in self.repositories {
+
+			let mut repo_path = String::from("/");
+			repo_path.push_str(&self.owner);
+			repo_path.push_str("/");
+			repo_path.push_str(&repo.repository_name);
+
+			repo_names.push(repo_path);
+		}
+		return (repo_names);
+	}
+}
+
+pub struct RepositoryTree {
+	pub repository_name: String,
+}


### PR DESCRIPTION
## Purpose

We eventually want to decouple the storage of repositories in which our client is interested from the peer connection itself. To support that decoupling, we'll use some structs which can then be moved to a more appropriate location.
#### What does this PR do?

Creates a couple of structs that would store owners and repositories for each owner in local memory.

These structs can be instantiated wherever necessary, and then the information passed to the protocol layer for use during swarm configuration / update.
